### PR TITLE
Add missing parameters in Ruler.m1

### DIFF
--- a/core/src/main/java/top/canyie/pine/Ruler.java
+++ b/core/src/main/java/top/canyie/pine/Ruler.java
@@ -6,7 +6,7 @@ package top.canyie.pine;
  */
 @SuppressWarnings("unused")
 final class Ruler {
-    private static native void m1();
+    private static native void m1(float f);
     private static native void m2();
 
     private interface I {


### PR DESCRIPTION
The last commit added a float parameter to the Ruler_m1 method in jni_bridge.h, but not to the java Ruler.m1() method.