### PR TITLE
[core]Fix assembly syntax error in thumb2.S

### DIFF
--- a/core/src/main/cpp/trampoline/arch/thumb2.S
+++ b/core/src/main/cpp/trampoline/arch/thumb2.S
@@ -10,6 +10,9 @@ name:
 .global name; \
 name:
 
+#define LDVAR(reg, var) \
+    ldr reg, var
+
 FUNCTION(pine_thumb_direct_jump_trampoline)
 ldr pc, pine_thumb_direct_jump_trampoline_jump_entry
 VAR(pine_thumb_direct_jump_trampoline_jump_entry)


### PR DESCRIPTION
- Added missing LDVAR macro definition in thumb2.S
- Corrected macro usage for loading variables into registers
- Ensured consistency with existing FUNCTION and VAR macro definitions

This resolves the compilation error: "expected ')'" at line 78.