### PR TITLE
[core] fix: disabling profile saver on A15 QPR1

### DIFF
--- a/core/src/main/cpp/android.cpp
+++ b/core/src/main/cpp/android.cpp
@@ -187,7 +187,7 @@ bool Android::DisableProfileSaver() {
             process_profiling_info = handle.GetSymbolAddress(symbol);
 
             // Android 15 QPR1
-            if (!process_profiling_info && version >= kV) {
+            if (!process_profiling_info) {
                 process_profiling_info = handle.GetSymbolAddress("_ZN3art12ProfileSaver20ProcessProfilingInfoEbPt");
             }
         }

--- a/core/src/main/cpp/android.cpp
+++ b/core/src/main/cpp/android.cpp
@@ -185,6 +185,11 @@ bool Android::DisableProfileSaver() {
                                               : version < kS ? "_ZN3art12ProfileSaver20ProcessProfilingInfoEbPt"
                                               : "_ZN3art12ProfileSaver20ProcessProfilingInfoEbbPt";
             process_profiling_info = handle.GetSymbolAddress(symbol);
+
+            // Android 15 QPR1
+            if (!process_profiling_info && version >= kV) {
+                process_profiling_info = handle.GetSymbolAddress("_ZN3art12ProfileSaver20ProcessProfilingInfoEbPt");
+            }
         }
     }
 


### PR DESCRIPTION
Android 15 QPR1 changed the signature of `ProfileSaver::ProcessProfilingInfo` back to the same as API <31
https://android.googlesource.com/platform/art/+/android15-qpr1-release/runtime/jit/profile_saver.cc#767

Porting over changes from our hooking project:
https://github.com/Aliucord/hook/commit/09c718cb0a9186c5301d9261c2ec62f5a25570fb#diff-43d8bf7b8884e1d727bafcf8dac88aac22b3999c0a4232e8b5ab5f31fda2c528R43-R49